### PR TITLE
fix(mcpack): check manifest include value before resolving

### DIFF
--- a/tools/mcpack.js
+++ b/tools/mcpack.js
@@ -1036,10 +1036,12 @@ export default class extends TOOL {
 	}
 	includeManifest(include, from, directory) {
 		this.currentDirectory = directory;
-		let path = this.resolveFilePath(this.resolveVariable(include));
-		if (!path)
-			throw new Error("'" + include + "': manifest not found!");
-		this.parseManifest(path, from);
+		if ("string" == typeof include) {
+			let path = this.resolveFilePath(this.resolveVariable(include));
+			if (!path)
+				throw new Error("'" + include + "': manifest not found!");
+			this.parseManifest(path, from);
+		}
 	}
 	mapBuiltins(builtins) {
 		const map = new Map;


### PR DESCRIPTION
While trying to build a project targeting the Raspberry Pi Pico with `mcpack`, I ran into an error:
```
### TypeError: call: not a function
```

All other platform targets were working, so I started exploring the cause.

After digging around the source code for `mcpack`, I narrowed down the issue to how the tool resolves modules from included manifest.json files. This led to the [arducam module](https://github.com/Moddable-OpenSource/moddable/blob/public/modules/io/imagein/arducam_hm01b0/manifest.json#L6-L22) for the ECMA-419 image/in implementation, which uses a git include for the Pico. 

When comparing `mcpack` with the `mcmanifest` tool, I noticed the latter [has support for git sources](https://github.com/Moddable-OpenSource/moddable/blob/public/tools/mcmanifest.js#L1913) that is missing from `mcpack`. 

This PR fixes the current error by checking the type of the `include` field's value before attempting to resolve the expected string path to the included module. 

----

I'm not sure if git support should be added to mcpack if the evaluated manifest from mcpack still goes through mcconfig (a subclass of mcmanifest).